### PR TITLE
Handle RECORD_NOT_IN_PROCESS errors: raise RecordNotInProcessError

### DIFF
--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -169,6 +169,7 @@ module ZohoHub
         raise MandatoryNotFound, response.msg if response.mandatory_not_found?
         raise RecordInBlueprint, response.msg if response.record_in_blueprint?
         raise TooManyRequestsError, response.msg if response.too_many_requests?
+        raise RecordNotInProcessError, response.msg if response.record_not_in_process?
 
         response
       end

--- a/lib/zoho_hub/errors.rb
+++ b/lib/zoho_hub/errors.rb
@@ -34,6 +34,9 @@ module ZohoHub
   class TooManyRequestsError < StandardError
   end
 
+  class RecordNotInProcessError < StandardError
+  end
+
   class ZohoAPIError < StandardError
   end
 end

--- a/lib/zoho_hub/response.rb
+++ b/lib/zoho_hub/response.rb
@@ -46,6 +46,10 @@ module ZohoHub
       error_code?('TOO_MANY_REQUESTS')
     end
 
+    def record_not_in_process?
+      error_code?('RECORD_NOT_IN_PROCESS')
+    end
+
     def empty?
       @params.empty?
     end


### PR DESCRIPTION
It seems that when we try to apply a Blueprint transition on a record that is not in this  Blueprint, Zoho returns a `RECORD_NOT_IN_PROCESS` error. cf production console :

```irb
> Zoho::AccountStatusTransitionJob.perform_now("2024207000044522066", "On Hold", "No Response")
Performing Zoho::AccountStatusTransitionJob (Job ID: e6dee667-6c6a-4ae0-86b7-24c511992aad) from Sidekiq(zoho) enqueued at  with arguments: "2024207000044522066", "On Hold", "No Response"
Performed Zoho::AccountStatusTransitionJob (Job ID: e6dee667-6c6a-4ae0-86b7-24c511992aad) from Sidekiq(zoho) in 2562.66ms
=> #<ZohoHub::Response:0x000055ae431d2af8 @params={:code=>"RECORD_NOT_IN_PROCESS", :details=>{}, :message=>"record not in process", :status=>"error"}>
```