### PR TITLE
Handle `RESOURCE_NOT_FOUND` error code

### DIFF
--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -165,6 +165,7 @@ module ZohoHub
         raise RecordInBlueprint, response.msg if response.record_in_blueprint?
         raise TooManyRequestsError, response.msg if response.too_many_requests?
         raise RecordNotInProcessError, response.msg if response.record_not_in_process?
+        raise RecordNotFound, response.msg if response.record_not_found?
 
         response
       end

--- a/lib/zoho_hub/response.rb
+++ b/lib/zoho_hub/response.rb
@@ -50,6 +50,10 @@ module ZohoHub
       error_code?('RECORD_NOT_IN_PROCESS')
     end
 
+    def record_not_found?
+      error_code?('RESOURCE_NOT_FOUND')
+    end
+
     def empty?
       @params.empty?
     end


### PR DESCRIPTION
To have a better error on :

<img width="1218" alt="Capture d’écran 2021-11-19 à 16 43 03" src="https://user-images.githubusercontent.com/56898600/142650370-e48fe06e-ddc2-4b18-8b45-7d0165cd73af.png">

Airbrake error: https://wecasa.airbrake.io/projects/202999/groups/3145148818552487712

On production console:

```irb
> csv_orders = Zoho::BulkJob.results("2024207000379522093")
lib/zoho_hub/base_record.rb:176:in `block in initialize': no implicit conversion of Symbol into Integer (TypeError)
> body = Zoho::BulkJob.get(File.join(Zoho::BulkJob.request_path, "2024207000379522093".to_s))
=> {:status=>"error", :code=>"RESOURCE_NOT_FOUND", :message=>"The requested resource doesn't exist.", :details=>{:resource=>"2024207000379522093"}}
```