### PR TITLE
Handle the "Invalid query" error

### DIFF
--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -176,6 +176,7 @@ module ZohoHub
         raise InvalidTokenError, response.msg if response.invalid_token?
         raise InternalError, response.msg if response.internal_error?
         raise InvalidRequestError, response.msg if response.invalid_request?
+        raise InvalidQueryError, response.msg if response.invalid_query?
         raise RecordInvalid, response.msg if response.invalid_data?
         raise InvalidModule, response.msg if response.invalid_module?
         raise NoPermission, response.msg if response.no_permission?

--- a/lib/zoho_hub/errors.rb
+++ b/lib/zoho_hub/errors.rb
@@ -13,6 +13,8 @@ module ZohoHub
 
   class InvalidRequestError < Error; end
 
+  class InvalidQueryError < Error; end
+
   class InvalidModule < Error; end
 
   class NoPermission < Error; end

--- a/lib/zoho_hub/response.rb
+++ b/lib/zoho_hub/response.rb
@@ -22,6 +22,10 @@ module ZohoHub
       error_code?('INVALID_REQUEST')
     end
 
+    def invalid_query?
+      error_code?('INVALID_QUERY')
+    end
+
     def authentication_failure?
       error_code?('AUTHENTICATION_FAILURE')
     end


### PR DESCRIPTION
To fix:

```
> Zoho::Account.where(criteria: '(Something:Equals:Foo)')
[ZohoHub] GET Accounts/search with {:criteria=>"(Something:Equals:Foo)"}
I, [2023-01-05T16:32:52.582535 #80944]  INFO -- request: GET https://www.zohoapis.com/crm/v2/Accounts/search?criteria=%28Something%3AEquals%3AFoo%29
I, [2023-01-05T16:32:52.582719 #80944]  INFO -- request: Authorization: "Zoho-oauthtoken xxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
User-Agent: "Faraday v1.10.2"
I, [2023-01-05T16:32:54.523247 #80944]  INFO -- response: {"code":"INVALID_QUERY","details":{"reason":"the field is not available for search","api_name":"Something"},"message":"invalid query formed","status":"error"}

TypeError: no implicit conversion of Symbol into Integer
from ~/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/bundler/gems/zoho_hub-b8ec7dfb3443/lib/zoho_hub/base_record.rb:200:in `block in initialize'
```