### PR TITLE
👔 Access token evaluate on runtime

### DIFF
--- a/lib/zoho_hub/connection.rb
+++ b/lib/zoho_hub/connection.rb
@@ -20,7 +20,7 @@ module ZohoHub
       end
     end
 
-    attr_accessor :debug, :access_token, :expires_in, :api_domain, :api_version, :refresh_token
+    attr_accessor :debug, :expires_in, :api_domain, :api_version, :refresh_token
 
     # This is a block to be run when the token is refreshed. This way you can do whatever you want
     # with the new parameters returned by the refresh method.
@@ -65,6 +65,10 @@ module ZohoHub
 
       response = with_refresh { adapter.delete(path, params) }
       response.body
+    end
+
+    def access_token
+      @access_token.try(:call) || @access_token
     end
 
     def access_token?

--- a/lib/zoho_hub/connection.rb
+++ b/lib/zoho_hub/connection.rb
@@ -68,7 +68,7 @@ module ZohoHub
     end
 
     def access_token
-      @access_token.try(:call) || @access_token
+      @access_token.respond_to?(:call) ? @access_token.call : @access_token
     end
 
     def access_token?

--- a/spec/zoho_hub/connection_spec.rb
+++ b/spec/zoho_hub/connection_spec.rb
@@ -57,4 +57,15 @@ RSpec.describe ZohoHub::Connection do
       end
     end
   end
+
+  describe '#access_token' do
+
+    it "returns access_token string value" do
+      expect(described_class.new(access_token: '123').access_token).to eq('123')
+    end
+
+    it "returns value from proc call" do
+      expect(described_class.new(access_token: -> { '123' }).access_token).to eq('123')
+    end
+  end
 end

--- a/spec/zoho_hub/connection_spec.rb
+++ b/spec/zoho_hub/connection_spec.rb
@@ -60,11 +60,11 @@ RSpec.describe ZohoHub::Connection do
 
   describe '#access_token' do
 
-    it "returns access_token string value" do
+    it 'returns access_token string value' do
       expect(described_class.new(access_token: '123').access_token).to eq('123')
     end
 
-    it "returns value from proc call" do
+    it 'returns value from proc call' do
       expect(described_class.new(access_token: -> { '123' }).access_token).to eq('123')
     end
   end

--- a/spec/zoho_hub/connection_spec.rb
+++ b/spec/zoho_hub/connection_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe ZohoHub::Connection do
   end
 
   describe '#access_token' do
-
     it 'returns access_token string value' do
       expect(described_class.new(access_token: '123').access_token).to eq('123')
     end


### PR DESCRIPTION
Allow access token to be assigned to either a `proc` or `lambda` so that it has the ability to fetch the `access_token` on runtime, together with `on_refresh_cb` it's possible to store the `access_token` into a cache(redis) where the token can be shared across multiple ruby processes 

Example in rails 
```ruby
ZohoHub.setup_connection(
  access_token: -> { Rails.cache.fetch(:zoho_access_token) }
)
ZohoHub.on_refresh do |params|
  Rails.cache.write(:zoho_access_token, params[:access_token])
end
```