### PR TITLE
✨ ZohoHub initialize faraday connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ ZohoHub.configure do |config|
   # config.debug      = true # this will be VERY verbose, but helps to identify bugs / problems
 end
 ```
+#### 2.1 Customize faraday connection
+
+To customize faraday connection with `on_initialize_connection`, example:
+
+```ruby
+ZohoHub.on_initialize_connection do |conn|
+  conn.adapter(:net_http_persistent, pool_size: 20) do |http|
+    http.idle_timeout = 300
+    http.read_timeout = 60
+  end
+end
+```
 
 ---
 
@@ -206,6 +218,23 @@ To use an **access token** in a manual request, include it as a request header a
 
 To use an **access token** with ZohoHub, pass it to the `ZohoHub.setup_connection` method as the
 `access_token` parameter.
+
+#### 4.1 Cache access token
+
+To cache you can use `on_refresh_cb`, example:
+```ruby
+ZohoHub.on_refresh do |params|
+  Rails.cache.write(:zoho_access_token, params[:access_token])
+end
+```
+
+And pass pass a `proc` or `lambda` to `access_token`.
+
+```ruby
+ZohoHub.setup_connection(
+  access_token: -> { ... }
+)
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ To use an **access token** with ZohoHub, pass it to the `ZohoHub.setup_connectio
 
 #### 4.1 Cache access token
 
-To cache you can use `on_refresh_cb`, example:
+To cache `access_token` value, configure `on_refresh` to write to a cache, example:
 ```ruby
 ZohoHub.on_refresh do |params|
   Rails.cache.write(:zoho_access_token, params[:access_token])
@@ -232,7 +232,7 @@ And pass pass a `proc` or `lambda` to `access_token`.
 
 ```ruby
 ZohoHub.setup_connection(
-  access_token: -> { ... }
+  access_token: -> { Rails.cache.fetch(:zoho_access_token) }
 )
 ```
 

--- a/lib/zoho_hub.rb
+++ b/lib/zoho_hub.rb
@@ -37,6 +37,10 @@ module ZohoHub
     @connection.on_refresh_cb = block
   end
 
+  def on_initialize_connection(&block)
+    @connection.on_initialize_connection = block
+  end
+
   def setup_connection(params = {})
     raise "ERROR: #{params[:error]}" if params[:error]
 

--- a/lib/zoho_hub/connection.rb
+++ b/lib/zoho_hub/connection.rb
@@ -115,7 +115,7 @@ module ZohoHub
     end
 
     def adapter
-      Faraday.new(url: base_url) do |conn|
+      @faraday_connection ||= Faraday.new(url: base_url) do |conn|
         conn.headers['Authorization'] = authorization if access_token?
         conn.request :json
         conn.response :json, parser_options: { symbolize_names: true }

--- a/lib/zoho_hub/connection.rb
+++ b/lib/zoho_hub/connection.rb
@@ -24,7 +24,7 @@ module ZohoHub
 
     # This is a block to be run when the token is refreshed. This way you can do whatever you want
     # with the new parameters returned by the refresh method.
-    attr_accessor :on_refresh_cb
+    attr_accessor :on_refresh_cb, :on_initialize_connection
 
     DEFAULT_DOMAIN = 'https://www.zohoapis.eu'
 
@@ -123,6 +123,7 @@ module ZohoHub
           conn.response :logger, ::Logger.new($stdout), headers: true, bodies: true
         end
         conn.adapter Faraday.default_adapter
+        @on_initialize_connection.call(conn) if @on_initialize_connection
       end
     end
   end

--- a/lib/zoho_hub/connection.rb
+++ b/lib/zoho_hub/connection.rb
@@ -115,7 +115,7 @@ module ZohoHub
     end
 
     def adapter
-      @faraday_connection ||= Faraday.new(url: base_url) do |conn|
+      @adapter ||= Faraday.new(url: base_url) do |conn|
         conn.headers['Authorization'] = authorization if access_token?
         conn.request :json
         conn.response :json, parser_options: { symbolize_names: true }

--- a/spec/zoho_hub_spec.rb
+++ b/spec/zoho_hub_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe ZohoHub do
 
   describe '#on_initialize_connection' do
     it 'calls the proc once' do
-      proc = spy()
+      init_connection = spy
       described_class.on_initialize_connection do
-        proc.call
+        init_connection.call
       end
       described_class.connection.send(:adapter)
-      expect(proc).to have_received(:call)
+      expect(init_connection).to have_received(:call)
     end
   end
 end

--- a/spec/zoho_hub_spec.rb
+++ b/spec/zoho_hub_spec.rb
@@ -6,13 +6,12 @@ RSpec.describe ZohoHub do
   end
 
   describe '#on_initialize_connection' do
-    let(:proc) { double('Proc', call: true) }
+    let(:initialize_connection) { -> { true } }
 
     it "calls the proc once" do
-      expect do |block|
-        ZohoHub.on_initialize_connection(&block)
-        ZohoHub.connection.send(:adapter)
-      end.to yield_control
+      ZohoHub.on_initialize_connection(&initialize_connection)
+      expect(initialize_connection).to receive(:call)
+      ZohoHub.connection.send(:adapter)
     end
   end
 end

--- a/spec/zoho_hub_spec.rb
+++ b/spec/zoho_hub_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe ZohoHub do
   end
 
   describe '#on_initialize_connection' do
-    let(:initialize_connection) { double('initialize_connection', call: true) }
+    let(:initialize_connection) { spy('initialize_connection') }
 
     it 'calls the proc once' do
       described_class.on_initialize_connection do
         initialize_connection.call
       end
-      expect(initialize_connection).to receive(:call)
       described_class.connection.send(:adapter)
+      expect(initialize_connection).to have_received(:call)
     end
   end
 end

--- a/spec/zoho_hub_spec.rb
+++ b/spec/zoho_hub_spec.rb
@@ -4,4 +4,15 @@ RSpec.describe ZohoHub do
   it 'has a version number' do
     expect(ZohoHub::VERSION).not_to be nil
   end
+
+  describe '#on_initialize_connection' do
+    let(:proc) { double('Proc', call: true) }
+
+    it "calls the proc once" do
+      expect do |block|
+        ZohoHub.on_initialize_connection(&block)
+        ZohoHub.connection.send(:adapter)
+      end.to yield_control
+    end
+  end
 end

--- a/spec/zoho_hub_spec.rb
+++ b/spec/zoho_hub_spec.rb
@@ -6,15 +6,13 @@ RSpec.describe ZohoHub do
   end
 
   describe '#on_initialize_connection' do
-    let(:initialize_connection) { spy('initialize_connection') }
-
     it 'calls the proc once' do
+      proc = spy()
       described_class.on_initialize_connection do
-        initialize_connection.call
+        proc.call
       end
       described_class.connection.send(:adapter)
-      expect(initialize_connection).to have_received(:call)
-      described_class.connection.send(:adapter)
+      expect(proc).to have_received(:call)
     end
   end
 end

--- a/spec/zoho_hub_spec.rb
+++ b/spec/zoho_hub_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ZohoHub do
       described_class.on_initialize_connection do
         init_connection.call
       end
+      described_class.connection.instance_variable_set(:@adapter, nil)
       described_class.connection.send(:adapter)
       expect(init_connection).to have_received(:call)
     end

--- a/spec/zoho_hub_spec.rb
+++ b/spec/zoho_hub_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe ZohoHub do
       end
       described_class.connection.send(:adapter)
       expect(initialize_connection).to have_received(:call)
+      described_class.connection.send(:adapter)
     end
   end
 end

--- a/spec/zoho_hub_spec.rb
+++ b/spec/zoho_hub_spec.rb
@@ -6,12 +6,14 @@ RSpec.describe ZohoHub do
   end
 
   describe '#on_initialize_connection' do
-    let(:initialize_connection) { -> { true } }
+    let(:initialize_connection) { double('initialize_connection', call: true) }
 
-    it "calls the proc once" do
-      ZohoHub.on_initialize_connection(&initialize_connection)
+    it 'calls the proc once' do
+      described_class.on_initialize_connection do
+        initialize_connection.call
+      end
       expect(initialize_connection).to receive(:call)
-      ZohoHub.connection.send(:adapter)
+      described_class.connection.send(:adapter)
     end
   end
 end


### PR DESCRIPTION
add `on_initialize_connection` callback to allow faraday connection customisation, one usage is to reconfigure faraday adapter to use `net_http_persistent`

below is a rough benchmark between `net_http` vs `net_http_persistent`  
```ruby
[2] pry(main)> zoho_connection = ZohoHub.connection
=> #<ZohoHub::Connection:0x00000001499dc4f8
 @access_token="...,
 @api_domain="https://www.zohoapis.com",
 @api_version="v2",
 @expires_in=3600,
 @refresh_token="...">
[3] pry(main)> zoho_connection.send(:adapter).adapter
=> Faraday::Adapter::NetHttp
[4] pry(main)> Benchmark.realtime { 20.times { Zoho::Account.find(zoho_id) } }
=> 20.970606999937445

def zoho_connection.adapter
  @faraday_connection ||= Faraday.new(url: base_url) do |conn|
    conn.headers['Authorization'] = authorization if access_token?
    conn.request :json
    conn.response :json, parser_options: { symbolize_names: true }
    if ZohoHub.configuration.debug?
      conn.response :logger, ::Logger.new($stdout), headers: true, bodies: true
    end
    conn.adapter(:net_http_persistent, pool_size: 20) do |http|
      http.idle_timeout = 300
      http.read_timeout = 60
    end
  end
end
=> :adapter
[6] pry(main)> zoho_connection.send(:adapter).adapter
=> Faraday::Adapter::NetHttpPersistent
[7] pry(main)> Benchmark.realtime { 20.times { Zoho::Account.find(zoho_id) } }
=> 12.295805000234395
```

Usage configuration would be like
```ruby
ZohoHub.on_initialize_connection do |conn|
  conn.adapter(:net_http_persistent, pool_size: 20) do |http|
    http.idle_timeout = 300
    http.read_timeout = 60
  end
end
```