### PR TITLE
🐛 Zoho hub access token bugfix

### DIFF
--- a/lib/zoho_hub/connection.rb
+++ b/lib/zoho_hub/connection.rb
@@ -115,7 +115,7 @@ module ZohoHub
 
     # The authorization header that must be added to every request for authorized requests.
     def authorization
-      "Zoho-oauthtoken #{@access_token}"
+      "Zoho-oauthtoken #{access_token}"
     end
 
     def adapter

--- a/spec/zoho_hub/connection_spec.rb
+++ b/spec/zoho_hub/connection_spec.rb
@@ -69,7 +69,9 @@ RSpec.describe ZohoHub::Connection do
   end
 
   describe '#authorization' do
-    let(:authorization_header) { described_class.new(access_token: -> { '123' }).send(:authorization) }
+    let(:authorization_header) do
+      described_class.new(access_token: -> { '123' }).send(:authorization)
+    end
 
     it 'returns zoho oauthtoken header value' do
       expect(authorization_header).to eq('Zoho-oauthtoken 123')

--- a/spec/zoho_hub/connection_spec.rb
+++ b/spec/zoho_hub/connection_spec.rb
@@ -67,4 +67,11 @@ RSpec.describe ZohoHub::Connection do
       expect(described_class.new(access_token: -> { '123' }).access_token).to eq('123')
     end
   end
+
+  describe '#authorization' do
+    subject { described_class.new(access_token: -> { '123' }).send(:authorization) }
+    it 'returns zoho oauthtoken header value' do
+      expect(subject).to eq('Zoho-oauthtoken 123')
+    end
+  end
 end

--- a/spec/zoho_hub/connection_spec.rb
+++ b/spec/zoho_hub/connection_spec.rb
@@ -69,10 +69,10 @@ RSpec.describe ZohoHub::Connection do
   end
 
   describe '#authorization' do
-    subject { described_class.new(access_token: -> { '123' }).send(:authorization) }
+    let(:authorization_header) { described_class.new(access_token: -> { '123' }).send(:authorization) }
 
     it 'returns zoho oauthtoken header value' do
-      expect(subject).to eq('Zoho-oauthtoken 123')
+      expect(authorization_header).to eq('Zoho-oauthtoken 123')
     end
   end
 end

--- a/spec/zoho_hub/connection_spec.rb
+++ b/spec/zoho_hub/connection_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe ZohoHub::Connection do
 
   describe '#authorization' do
     subject { described_class.new(access_token: -> { '123' }).send(:authorization) }
+
     it 'returns zoho oauthtoken header value' do
       expect(subject).to eq('Zoho-oauthtoken 123')
     end


### PR DESCRIPTION
from this PR https://github.com/wecasa/zoho_hub/pull/13 `access_token` is now evaluated on runtime, 
this fixes `authorization` which is not calling the proc for `@access_token` 