### PR TITLE
🐛 Zoho connection authorization token refresh

### DIFF
--- a/lib/zoho_hub/connection.rb
+++ b/lib/zoho_hub/connection.rb
@@ -88,6 +88,8 @@ module ZohoHub
     private
 
     def with_refresh
+      adapter.headers['Authorization'] = authorization if access_token?
+
       http_response = yield
 
       response = Response.new(http_response.body)

--- a/spec/zoho_hub/connection_spec.rb
+++ b/spec/zoho_hub/connection_spec.rb
@@ -113,7 +113,6 @@ RSpec.describe ZohoHub::Connection do
 
       context 'with access_token as lambda' do
         let(:connection) { described_class.new(access_token: -> { 'bar' }, refresh_token: 'xxx') }
-        let(:adapter) { connection.send(:adapter) }
 
         it 'does not change the access_token value' do
           expect(connection.access_token).to eq('bar')

--- a/spec/zoho_hub/connection_spec.rb
+++ b/spec/zoho_hub/connection_spec.rb
@@ -128,14 +128,17 @@ RSpec.describe ZohoHub::Connection do
 
     context 'when request has valid authorization token' do
       context 'with access_token as lambda' do
-
-        let(:connection) { described_class.new(access_token: -> { "bar#{enum.next}" }, refresh_token: 'xxx') }
+        let(:connection) do
+          described_class.new(access_token: -> { "bar#{enum.next}" }, refresh_token: 'xxx')
+        end
         let(:adapter) { connection.send(:adapter) }
         let(:enum) { [123, 456].cycle }
 
         it 'ensures to always use the current access token value' do
           expect(adapter.headers['Authorization']).to eq('Zoho-oauthtoken bar123')
-          connection.send(:with_refresh) { instance_double('Response', body: { data: [ { code: nil } ] }) }
+          connection.send(:with_refresh) do
+            instance_double('Response', body: { data: [{ code: nil }] })
+          end
           expect(adapter.headers['Authorization']).to eq('Zoho-oauthtoken bar456')
         end
       end


### PR DESCRIPTION
There is a bug introduced on this PR https://github.com/wecasa/zoho_hub/pull/14/files
since the `adapter` is memoized we need to always set the authorization header properly on every request 